### PR TITLE
fix: Don't override first value of enum in is()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "permissible",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "permissible",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "bigint-buffer": "^1.1.5"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -80,3 +80,11 @@ test('string length', () => {
 test('base64', () => {
   expect(() => Permissions.fromBase64('aa?d', schema)).toThrow('Invalid base64 string');
 });
+
+test('should allow using the first enum value', () => {
+  const permissions: Permissions<typeof jsonSchema> = Permissions.fromJson(json, schema);
+
+  expect(permissions.is(schema.fields.type, schema.fields.type.user)).toBe(true);
+  permissions.set(schema.fields.type, schema.fields.type.moderator);
+  expect(permissions.is(schema.fields.type, schema.fields.type.moderator)).toBe(true);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export class Permissions<T extends JsonSchema> {
   }
 
   is(field: Field, value?: bigint): boolean {
-    if (!value) value = 1n;
+    if (value === undefined) value = 1n;
 
     if (field.length === 1n) {
       return !!(this.permissions & (1n << field.index)) === !!value;


### PR DESCRIPTION
Hi! First of all, thanks for this lib! It's exactly what I was looking for with a personal project I'm working on.

This fixes a small bug where the first value of an enum could not be asserted with `is()`. I added a test which shows where this would fail before.

Thanks!